### PR TITLE
chore: update .gitignore to exclude common development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,18 @@ Thumbs.db
 
 # Temporary files
 *.tmp
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# Package manager files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Local development
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
Add entries to exclude test coverage directories, package manager lock files, and local environment files to prevent them from being tracked in version control